### PR TITLE
Set minimum PHP version to 7.0 or above

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "dopamedia/module-base-price",
   "description": "N/A",
   "require": {
-    "php": "7.0.2|7.0.4|~7.0.6"
+    "php": "^7.0"
   },
   "type": "magento2-module",
   "version": "1.0.0",


### PR DESCRIPTION
Having problems with PHP version cannot install when PHP > 7.0.x